### PR TITLE
add ipv4 option for ifconfig.io

### DIFF
--- a/ddns.cpp
+++ b/ddns.cpp
@@ -7,7 +7,7 @@ int main(){
  FILE *file;
  char buffer[128];
  char *pcmd;
- strcpy(buffer,"curl ifconfig.io > /tmp/gbip.buff");
+ strcpy(buffer,"curl ifconfig.io -4 > /tmp/gbip.buff");
  pcmd=(char*)buffer;
  system(pcmd);
  file=fopen("/tmp/gbip.buff","r");


### PR DESCRIPTION
https://ifconfig.io/ から IPv6 アドレスが返ってくることがあったため、 IPv4 を返すように変更しました。